### PR TITLE
changed config options for 'start' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack -p",
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --host 0.0.0.0 --port 8080",
     "start-debug": "webpack --display-error-details",
     "lint-code": "eslint src",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
The default initialization of webpack-dev-server uses 127.0.0.1 for a "localhost" connection.  Since I am using a bridged connection in my virtualbox VM to host my dev server, this was not happy.  Changing the host to 0.0.0.0 (a wildcard value I think) makes it resolve correctly.