### PR TITLE
Cache static assets

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,8 +8,9 @@ var port = isProduction ? process.env.PORT : 3000;
 var publicPath = path.resolve(__dirname, 'build');
 
 // We point to our static assets
-app.use(express.static(publicPath));
-
+app.use(express.static(publicPath, {
+  maxage: '4h'
+}));
 // Redirect all non-static requests to our app
 app.get('/*', function(req, res){
   res.sendFile(publicPath + '/index.html');


### PR DESCRIPTION
This small change will cache static assets and save a lot of load on subsequent page views.
<img width="1148" alt="screen shot 2017-04-25 at 3 42 39 pm" src="https://cloud.githubusercontent.com/assets/1127238/25404416/dd07dbb4-29cd-11e7-95f0-75a515792ec0.png">
